### PR TITLE
Ensure bucket exists in db.Keys

### DIFF
--- a/boltons.go
+++ b/boltons.go
@@ -257,6 +257,9 @@ func (db *DB) Keys(s interface{}) ([]string, error) {
 
 	err = db.bolt.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(bucket.name)
+		if bucket == nil {
+			return nil
+		}
 		cursor := bucket.Cursor()
 
 		for key, _ := cursor.First(); key != nil; key, _ = cursor.Next() {

--- a/boltons_test.go
+++ b/boltons_test.go
@@ -6,6 +6,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type UnknownStruct struct {
+	ID string
+}
+
 type TestStruct struct {
 	ID         string
 	TestString string
@@ -172,6 +176,15 @@ func TestKeys(t *testing.T) {
 	keys, err = db.Keys(&TestStruct{})
 	assert.NoError(err, "should not error")
 	assert.NotEqual(len(keys), 0, "should have keys")
+
+	keys, err = db.Keys(UnknownStruct{})
+	assert.NoError(err, "should not error")
+	assert.Equal(len(keys), 0, "should not have keys")
+
+	keys, err = db.Keys(&UnknownStruct{})
+	assert.NoError(err, "should not error")
+	assert.Equal(len(keys), 0, "should have keys")
+
 }
 
 func TestExists(t *testing.T) {


### PR DESCRIPTION
Trying to create a cursor on a nil bucket causes a panic. Simple check to see if bucket is null and test.
